### PR TITLE
fix parsing STAP-A

### DIFF
--- a/rtp_h264_extractor.lua
+++ b/rtp_h264_extractor.lua
@@ -122,8 +122,8 @@ do
             repeat
                 size = h264_data:tvb()(offset, 2):uint()
                 offset = offset + 2
-				local next_nal_type = bit.band(h264_data:get_index(offset), 0x1f)
-				log("STAP-A has naltype = "..next_nal_type..", size = "..size)
+                local next_nal_type = bit.band(h264_data:get_index(offset), 0x1f)
+                log("STAP-A has naltype = "..next_nal_type..", size = "..size)
                 fp:write("\00\00\00\01")
                 fp:write(h264_data:tvb()():raw(offset, size))
                 offset = offset + size
@@ -198,8 +198,8 @@ do
                     max_packet_count = max_packet_count + 1
                 end
             else 
-				packet_count = packet_count + 1
-				
+                packet_count = packet_count + 1
+                
                 for i, payload in ipairs(payloadTable) do
                     on_h264_rtp_payload(seqTable[1], payload)
                 end

--- a/rtp_h264_extractor.lua
+++ b/rtp_h264_extractor.lua
@@ -188,10 +188,10 @@ do
             local payloadTable = { h264_data() }
             local seqTable = { rtp_seq() }
             
---            if (#payloadTable) ~= (#seqTable) then 
---                log("ERROR: payloadTable size is "..tostring(#payloadTable)..", seqTable size is "..tostring(#seqTable))
---                return
---            end
+            if (#payloadTable) < (#seqTable) then 
+                log("ERROR: payloadTable size is "..tostring(#payloadTable)..", seqTable size is "..tostring(#seqTable))
+                return
+            end
             
             if pass == 0 then 
                 for i, payload in ipairs(payloadTable) do

--- a/rtp_h264_extractor.lua
+++ b/rtp_h264_extractor.lua
@@ -117,11 +117,11 @@ do
         end
         
         local function handle_stap_a(h264_data)
-			log("start dump stap nals")
+            log("start dump stap nals")
             offset = 1		-- skip nal header of STAP-A
             repeat
                 size = h264_data:tvb()(offset, 2):uint()
-				offset = offset + 2
+                offset = offset + 2
 				local next_nal_type = bit.band(h264_data:get_index(offset), 0x1f)
 				log("STAP-A has naltype = "..next_nal_type..", size = "..size)
                 fp:write("\00\00\00\01")


### PR DESCRIPTION
STAP-A frames can have more than one item at payloadTable (my sniff has 4: STAP-A + SPS + PPS + part_of_1st_I-frame), so length of payloadTable would not be equal to length of seqTable at h264_tap.packet() func.

Example of parsing:
Start
phase 1
phase 2:  max_packet_count = 1424
on_jitter_buffer_output:  seq = 56658, payload len = 1378
start dump stap nals
STAP-A has naltype = 7, size = 12
STAP-A has naltype = 8, size = 4
STAP-A has naltype = 5, size = 1355
finish dump stap nals
on_jitter_buffer_output:  seq = 56658, payload len = 1355
on_jitter_buffer_output:  seq = 56658, payload len = 1361
on_jitter_buffer_output:  seq = 56658, payload len = 1375
